### PR TITLE
feat(windows): unify runner dependency setup behind self-setup script

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -36,5 +36,7 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
+          RENOVATE_BASE_BRANCH_PATTERNS: ${{ github.ref_name }}
           RENOVATE_GIT_AUTHOR: ${{ secrets.RENOVATE_GIT_AUTHOR }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_USE_BASE_BRANCH_CONFIG: merge

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -36,4 +36,5 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
+          RENOVATE_GIT_AUTHOR: ${{ secrets.RENOVATE_GIT_AUTHOR }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -34,5 +34,6 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.10
         with:
-          configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -391,6 +391,8 @@ jobs:
         shell: powershell
         run: |
           powershell -ExecutionPolicy Bypass -File scripts/windows/install_oscdimg.ps1
+          go mod vendor
+          go run cmd/main.go install --virtualbox
 
       - name: Run VirtualBox build
         id: packer_build
@@ -401,7 +403,6 @@ jobs:
           PACKER_LOG: 1
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go mod vendor
           make test-build-specific TEST_NAME=TestBuildVirtualBoxWindows11Amd64OnWindows
           make test-deploy-windows-hyperv
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,12 @@ through UAC if needed:
 
 ```powershell
 alchemy.exe install
+# optionally with Go and VirtualBox support:
+alchemy.exe install --with-go --virtualbox
 ```
 
 This runs
 [scripts/windows/dev-alchemy-self-setup.ps1](./scripts/windows/dev-alchemy-self-setup.ps1).
-Add `--with-go` when you also want the installer to upgrade or install Go.
 
 ### 3. Discover what your host supports
 

--- a/README.md
+++ b/README.md
@@ -164,12 +164,13 @@ alchemy install
 This runs
 [scripts/linux/dev-alchemy-install-dependencies.sh](./scripts/linux/dev-alchemy-install-dependencies.sh).
 
-On macOS and Linux, `alchemy install --with-go` also bootstraps the Go
-toolchain.
+On macOS, Linux, and Windows, `alchemy install --with-go` also bootstraps the
+Go toolchain.
 
 #### Windows
 
-Run the command in an elevated PowerShell session:
+Run the command from your normal shell. Windows will prompt for elevation
+through UAC if needed:
 
 ```powershell
 alchemy.exe install
@@ -177,6 +178,7 @@ alchemy.exe install
 
 This runs
 [scripts/windows/dev-alchemy-self-setup.ps1](./scripts/windows/dev-alchemy-self-setup.ps1).
+Add `--with-go` when you also want the installer to upgrade or install Go.
 
 ### 3. Discover what your host supports
 

--- a/build/docker/ansible-windows-ssh/Dockerfile
+++ b/build/docker/ansible-windows-ssh/Dockerfile
@@ -9,7 +9,7 @@ RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointMa
 RUN choco install -y cygwin --params \"/InstallDir:C:\cygwin64 /NoAdmin /NoStartMenu\"
 
 RUN choco install -y cyg-get
-RUN cyg-get python39 python39-pip python39-cryptography openssh git make gcc-core gcc-g++ libffi-devel openssl-devel sshpass
+RUN cyg-get python39 python39-pip python39-cryptography openssh git make gcc-core gcc-g++ libffi-devel libssl-devel sshpass
 
 # Install Ansible inside Cygwin
 RUN C:\\cygwin64\\bin\\python3.9.exe -m pip install ansible

--- a/build/docker/ansible-windows-winrm/Dockerfile
+++ b/build/docker/ansible-windows-winrm/Dockerfile
@@ -9,7 +9,7 @@ RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointMa
 RUN choco install -y cygwin --params \"/InstallDir:C:\cygwin64 /NoAdmin /NoStartMenu\"
 
 RUN choco install -y cyg-get
-RUN cyg-get python39 python39-pip python39-cryptography openssh git make gcc-core gcc-g++ libffi-devel openssl-devel
+RUN cyg-get python39 python39-pip python39-cryptography openssh git make gcc-core gcc-g++ libffi-devel libssl-devel
 
 # Install Ansible inside Cygwin
 RUN C:\\cygwin64\\bin\\python3.9.exe -m pip install ansible

--- a/build/gh_actions/windows-azure-gh-runner-packer-build.sh
+++ b/build/gh_actions/windows-azure-gh-runner-packer-build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+packer init windows-azure-gh-runner.pkr.hcl
 subscription_id="$(packer inspect -var-file=windows-azure-gh-runner-secrets.pkrvars.hcl windows-azure-gh-runner.pkr.hcl | grep subscription_id | cut -d'"' -f2)"
 location="eastus2"
 image_resource_group="gh-actions-images-${location// /-}"

--- a/build/gh_actions/windows-azure-gh-runner-secrets.pkrvars.hcl.example
+++ b/build/gh_actions/windows-azure-gh-runner-secrets.pkrvars.hcl.example
@@ -1,0 +1,2 @@
+subscription_id = "your-subscription-id"
+tenant_id       = "your-tenant-id"

--- a/build/gh_actions/windows-azure-gh-runner.pkr.hcl
+++ b/build/gh_actions/windows-azure-gh-runner.pkr.hcl
@@ -63,7 +63,7 @@ try {
 '@
 Set-Content -Path 'C:\AzureData\bootstrap.ps1' -Value $bootstrap
 EOF
-  windows_setup_command = var.virtualization_flavor == "virtualbox" ? "powershell.exe -ExecutionPolicy Bypass -File C:\\AzureData\\scripts\\windows\\dev-alchemy-self-setup.ps1 -VirtualBox" : "powershell.exe -ExecutionPolicy Bypass -File C:\\AzureData\\scripts\\windows\\dev-alchemy-self-setup.ps1"
+  windows_setup_command = var.virtualization_flavor == "virtualbox" ? "powershell.exe -ExecutionPolicy Bypass -File C:\\AzureData\\scripts\\windows\\dev-alchemy-self-setup.ps1 -WithGo -VirtualBox" : "powershell.exe -ExecutionPolicy Bypass -File C:\\AzureData\\scripts\\windows\\dev-alchemy-self-setup.ps1 -WithGo"
 
 }
 
@@ -127,6 +127,8 @@ build {
 
       # install host build packages via the shared windows setup script
       local.windows_setup_command,
+      "python --version",
+      "go version",
       # loader script to execute custom data on first boot
       "New-Item -Path 'C:\\AzureData' -ItemType Directory -Force",
       local.bootstrap_script,

--- a/build/gh_actions/windows-azure-gh-runner.pkr.hcl
+++ b/build/gh_actions/windows-azure-gh-runner.pkr.hcl
@@ -45,7 +45,7 @@ variable "virtualization_flavor" {
 }
 
 locals {
-  bootstrap_script   = <<EOF
+  bootstrap_script      = <<EOF
 $bootstrap = @'
 Set-Content -Path 'C:\AzureData\provision_log.txt' -Value 'Starting custom data execution...'
 try {
@@ -63,7 +63,7 @@ try {
 '@
 Set-Content -Path 'C:\AzureData\bootstrap.ps1' -Value $bootstrap
 EOF
-  virtualbox_install = var.virtualization_flavor == "virtualbox" ? "choco install -y virtualbox" : ""
+  windows_setup_command = var.virtualization_flavor == "virtualbox" ? "powershell.exe -ExecutionPolicy Bypass -File C:\\AzureData\\scripts\\windows\\dev-alchemy-self-setup.ps1 -VirtualBox" : "powershell.exe -ExecutionPolicy Bypass -File C:\\AzureData\\scripts\\windows\\dev-alchemy-self-setup.ps1"
 
 }
 
@@ -106,6 +106,11 @@ build {
     destination = "C:\\AzureData\\scripts\\windows\\install_oscdimg.ps1"
   }
 
+  provisioner "file" {
+    source      = "../../scripts/windows/dev-alchemy-self-setup.ps1"
+    destination = "C:\\AzureData\\scripts\\windows\\dev-alchemy-self-setup.ps1"
+  }
+
   provisioner "powershell" {
     inline = [
       # Wait for the Azure Guest Agent to be running
@@ -120,32 +125,8 @@ build {
       "Expand-Archive \"C:\\actions-runner.zip\" -DestinationPath \"C:\\actions-runner\"",
       "Remove-Item \"C:\\actions-runner.zip\"",
 
-      # install chocolatey
-      "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))",
-
-      # install python3 with chocolatey
-      "choco install -y python --version=3.13.11",
-
-      # install golang with chocolatey
-      "choco install -y golang",
-
-      # install git for windows with chocolatey
-      # includes bash
-      "choco install -y git",
-      # add bash.exe to the path for use in build scripts
-      "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';C:\\Program Files\\Git\\bin', 'Machine')",
-
-      # install make with chocolatey
-      "choco install -y make",
-
-      # install packer with chocolatey
-      "choco install -y packer",
-
-      # install azure cli with chocolatey
-      "choco install -y azure-cli",
-
-      # install virtualbox with chocolatey
-      local.virtualbox_install,
+      # install host build packages via the shared windows setup script
+      local.windows_setup_command,
       # loader script to execute custom data on first boot
       "New-Item -Path 'C:\\AzureData' -ItemType Directory -Force",
       local.bootstrap_script,

--- a/cmd/cmd/install.go
+++ b/cmd/cmd/install.go
@@ -17,7 +17,8 @@ type installCommandSpec struct {
 }
 
 type installCommandOptions struct {
-	withGo bool
+	withGo     bool
+	virtualBox bool
 }
 
 var runInstallCommand = func(spec installCommandSpec) error {
@@ -39,6 +40,10 @@ var runInstallCommand = func(spec installCommandSpec) error {
 }
 
 func installCommandForHost(hostOs alchemy_build.HostOsType, projectDir string, options installCommandOptions) (installCommandSpec, error) {
+	if options.virtualBox && hostOs != alchemy_build.HostOsWindows {
+		return installCommandSpec{}, fmt.Errorf("install --virtualbox is only supported for host OS: %s", hostOs)
+	}
+
 	switch hostOs {
 	case alchemy_build.HostOsDarwin:
 		scriptPath := filepath.Join(projectDir, "scripts", "macos", "dev-alchemy-install-dependencies.sh")
@@ -56,9 +61,13 @@ func installCommandForHost(hostOs alchemy_build.HostOsType, projectDir string, o
 			return installCommandSpec{}, fmt.Errorf("install --with-go is not supported for host OS: %s", hostOs)
 		}
 		scriptPath := filepath.Join(projectDir, "scripts", "windows", "dev-alchemy-self-setup.ps1")
+		args := []string{"-ExecutionPolicy", "Bypass", "-File", scriptPath}
+		if options.virtualBox {
+			args = append(args, "-VirtualBox")
+		}
 		return installCommandSpec{
 			executable: "powershell",
-			args:       []string{"-ExecutionPolicy", "Bypass", "-File", scriptPath},
+			args:       args,
 			scriptPath: scriptPath,
 		}, nil
 	case alchemy_build.HostOsLinux:
@@ -78,6 +87,7 @@ func installCommandForHost(hostOs alchemy_build.HostOsType, projectDir string, o
 }
 
 var installWithGo bool
+var installVirtualBox bool
 
 var installCmd = &cobra.Command{
 	Use:   "install",
@@ -87,7 +97,7 @@ var installCmd = &cobra.Command{
 		hostOs := alchemy_build.GetCurrentHostOs()
 		projectDir := alchemy_build.GetDirectoriesInstance().ProjectDir
 
-		spec, err := installCommandForHost(hostOs, projectDir, installCommandOptions{withGo: installWithGo})
+		spec, err := installCommandForHost(hostOs, projectDir, installCommandOptions{withGo: installWithGo, virtualBox: installVirtualBox})
 		if err != nil {
 			return err
 		}
@@ -99,5 +109,6 @@ var installCmd = &cobra.Command{
 
 func init() {
 	installCmd.Flags().BoolVar(&installWithGo, "with-go", false, "Also install the Go toolchain when supported on the current host OS")
+	installCmd.Flags().BoolVar(&installVirtualBox, "virtualbox", false, "Also install VirtualBox on Windows hosts")
 	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/cmd/install.go
+++ b/cmd/cmd/install.go
@@ -57,11 +57,11 @@ func installCommandForHost(hostOs alchemy_build.HostOsType, projectDir string, o
 			scriptPath: scriptPath,
 		}, nil
 	case alchemy_build.HostOsWindows:
-		if options.withGo {
-			return installCommandSpec{}, fmt.Errorf("install --with-go is not supported for host OS: %s", hostOs)
-		}
 		scriptPath := filepath.Join(projectDir, "scripts", "windows", "dev-alchemy-self-setup.ps1")
 		args := []string{"-ExecutionPolicy", "Bypass", "-File", scriptPath}
+		if options.withGo {
+			args = append(args, "-WithGo")
+		}
 		if options.virtualBox {
 			args = append(args, "-VirtualBox")
 		}

--- a/cmd/cmd/install_test.go
+++ b/cmd/cmd/install_test.go
@@ -49,6 +49,27 @@ func TestInstallCommandForHostWindows(t *testing.T) {
 	}
 }
 
+func TestInstallCommandForHostWindowsWithVirtualBox(t *testing.T) {
+	projectDir := filepath.Join("tmp", "dev-alchemy")
+
+	spec, err := installCommandForHost(alchemy_build.HostOsWindows, projectDir, installCommandOptions{virtualBox: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedScriptPath := filepath.Join(projectDir, "scripts", "windows", "dev-alchemy-self-setup.ps1")
+	expectedArgs := []string{"-ExecutionPolicy", "Bypass", "-File", expectedScriptPath, "-VirtualBox"}
+	if spec.executable != "powershell" {
+		t.Fatalf("expected powershell, got %q", spec.executable)
+	}
+	if spec.scriptPath != expectedScriptPath {
+		t.Fatalf("expected script path %q, got %q", expectedScriptPath, spec.scriptPath)
+	}
+	if !reflect.DeepEqual(spec.args, expectedArgs) {
+		t.Fatalf("expected args %v, got %v", expectedArgs, spec.args)
+	}
+}
+
 func TestInstallCommandForHostLinux(t *testing.T) {
 	projectDir := filepath.Join("tmp", "dev-alchemy")
 
@@ -103,6 +124,13 @@ func TestInstallCommandForHostWindowsWithGoUnsupported(t *testing.T) {
 	_, err := installCommandForHost(alchemy_build.HostOsWindows, "/tmp/dev-alchemy", installCommandOptions{withGo: true})
 	if err == nil {
 		t.Fatal("expected unsupported with-go error")
+	}
+}
+
+func TestInstallCommandForHostDarwinWithVirtualBoxUnsupported(t *testing.T) {
+	_, err := installCommandForHost(alchemy_build.HostOsDarwin, "/tmp/dev-alchemy", installCommandOptions{virtualBox: true})
+	if err == nil {
+		t.Fatal("expected unsupported virtualbox error")
 	}
 }
 

--- a/cmd/cmd/install_test.go
+++ b/cmd/cmd/install_test.go
@@ -70,6 +70,21 @@ func TestInstallCommandForHostWindowsWithVirtualBox(t *testing.T) {
 	}
 }
 
+func TestInstallCommandForHostWindowsWithGo(t *testing.T) {
+	projectDir := filepath.Join("tmp", "dev-alchemy")
+
+	spec, err := installCommandForHost(alchemy_build.HostOsWindows, projectDir, installCommandOptions{withGo: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedScriptPath := filepath.Join(projectDir, "scripts", "windows", "dev-alchemy-self-setup.ps1")
+	expectedArgs := []string{"-ExecutionPolicy", "Bypass", "-File", expectedScriptPath, "-WithGo"}
+	if !reflect.DeepEqual(spec.args, expectedArgs) {
+		t.Fatalf("expected args %v, got %v", expectedArgs, spec.args)
+	}
+}
+
 func TestInstallCommandForHostLinux(t *testing.T) {
 	projectDir := filepath.Join("tmp", "dev-alchemy")
 
@@ -117,13 +132,6 @@ func TestInstallCommandForHostLinuxWithGo(t *testing.T) {
 	expectedArgs := []string{expectedScriptPath, "--with-go"}
 	if !reflect.DeepEqual(spec.args, expectedArgs) {
 		t.Fatalf("expected args %v, got %v", expectedArgs, spec.args)
-	}
-}
-
-func TestInstallCommandForHostWindowsWithGoUnsupported(t *testing.T) {
-	_, err := installCommandForHost(alchemy_build.HostOsWindows, "/tmp/dev-alchemy", installCommandOptions{withGo: true})
-	if err == nil {
-		t.Fatal("expected unsupported with-go error")
 	}
 }
 

--- a/pkg/deploy/windows-hyperv-deploy.go
+++ b/pkg/deploy/windows-hyperv-deploy.go
@@ -22,6 +22,7 @@ const (
 
 var (
 	runHypervVagrantCommandWithEnv     = runCommandWithStreamingLogsWithEnv
+	runHypervCommandWithCombinedOutput = runCommandWithCombinedOutput
 	inspectHypervVagrantStartCmdTarget = inspectHypervVagrantStartTarget
 	inspectHypervVagrantStopTarget     = inspectHypervVagrantStartTarget
 	hypervVagrantMachineExistsChecker  = hypervVagrantMachineExists
@@ -189,62 +190,98 @@ func RunHypervVagrantStopOnWindows(config alchemy_build.VirtualMachineConfig) er
 		return err
 	}
 
-	if err := runHypervVagrantCommandWithEnv(
+	gracefulErr := runHypervVagrantGracefulStop(config, settings)
+
+	stopped, waitErr := waitForHypervVagrantStop(config, hypervVagrantStopSettleTimeout)
+	if waitErr == nil && stopped {
+		return nil
+	}
+	if gracefulErr == nil {
+		gracefulErr = fmt.Errorf("graceful stop completed but VM is still running after %s", hypervVagrantStopSettleTimeout)
+	}
+
+	forceErr := runHypervVagrantCommandWithEnv(
+		settings.VagrantDir,
+		20*time.Minute,
+		"vagrant",
+		[]string{"halt", "--force"},
+		settings.VagrantEnv,
+		fmt.Sprintf("%s:%s:%s:vagrant-halt-force", config.OS, config.UbuntuType, config.Arch),
+	)
+	if forceErr == nil {
+		stopped, waitErr = waitForHypervVagrantStop(config, hypervVagrantStopSettleTimeout)
+		if waitErr == nil && stopped {
+			return nil
+		}
+	}
+
+	if waitErr != nil {
+		return fmt.Errorf(
+			"failed to stop Vagrant VM for %s:%s:%s: graceful stop failed: %v; forced halt failed: %v; failed verifying final state: %w",
+			config.OS,
+			config.UbuntuType,
+			config.Arch,
+			gracefulErr,
+			forceErr,
+			waitErr,
+		)
+	}
+	if forceErr != nil {
+		return fmt.Errorf(
+			"failed to stop Vagrant VM for %s:%s:%s: graceful stop failed: %v; forced halt failed: %w",
+			config.OS,
+			config.UbuntuType,
+			config.Arch,
+			gracefulErr,
+			forceErr,
+		)
+	}
+	return fmt.Errorf(
+		"failed to stop Vagrant VM for %s:%s:%s: graceful stop failed: %v; forced halt completed but VM is still running",
+		config.OS,
+		config.UbuntuType,
+		config.Arch,
+		gracefulErr,
+	)
+}
+
+func runHypervVagrantGracefulStop(config alchemy_build.VirtualMachineConfig, settings hypervVagrantDeploySettings) error {
+	if config.OS == "ubuntu" {
+		return runHypervUbuntuGuestShutdown(settings.VagrantDir, settings.VagrantEnv)
+	}
+
+	return runHypervVagrantCommandWithEnv(
 		settings.VagrantDir,
 		20*time.Minute,
 		"vagrant",
 		[]string{"halt"},
 		settings.VagrantEnv,
 		fmt.Sprintf("%s:%s:%s:vagrant-halt", config.OS, config.UbuntuType, config.Arch),
-	); err != nil {
-		stopped, waitErr := waitForHypervVagrantStop(config, hypervVagrantStopSettleTimeout)
-		if waitErr == nil && stopped {
-			return nil
-		}
+	)
+}
 
-		forceErr := runHypervVagrantCommandWithEnv(
-			settings.VagrantDir,
-			20*time.Minute,
-			"vagrant",
-			[]string{"halt", "--force"},
-			settings.VagrantEnv,
-			fmt.Sprintf("%s:%s:%s:vagrant-halt-force", config.OS, config.UbuntuType, config.Arch),
-		)
-		if forceErr == nil {
-			stopped, waitErr = waitForHypervVagrantStop(config, hypervVagrantStopSettleTimeout)
-			if waitErr == nil && stopped {
-				return nil
-			}
-		}
+func runHypervUbuntuGuestShutdown(workingDir string, env []string) error {
+	vmName, err := hypervVagrantVMName(env)
+	if err != nil {
+		return err
+	}
 
-		if waitErr != nil {
-			return fmt.Errorf(
-				"failed to stop Vagrant VM for %s:%s:%s: graceful halt failed: %v; forced halt failed: %v; failed verifying final state: %w",
-				config.OS,
-				config.UbuntuType,
-				config.Arch,
-				err,
-				forceErr,
-				waitErr,
-			)
-		}
-		if forceErr != nil {
-			return fmt.Errorf(
-				"failed to stop Vagrant VM for %s:%s:%s: graceful halt failed: %v; forced halt failed: %w",
-				config.OS,
-				config.UbuntuType,
-				config.Arch,
-				err,
-				forceErr,
-			)
-		}
-		return fmt.Errorf(
-			"failed to stop Vagrant VM for %s:%s:%s: graceful halt failed: %v; forced halt completed but VM is still running",
-			config.OS,
-			config.UbuntuType,
-			config.Arch,
-			err,
-		)
+	output, err := runHypervCommandWithCombinedOutput(
+		workingDir,
+		2*time.Minute,
+		"powershell",
+		[]string{
+			"-NoProfile",
+			"-NonInteractive",
+			"-Command",
+			fmt.Sprintf(
+				"Import-Module Hyper-V -ErrorAction Stop; Stop-VM -Name %s -Confirm:$false -ErrorAction Stop | Out-Null",
+				powershellSingleQuote(vmName),
+			),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to request graceful Hyper-V shutdown for VM %q: %w; output: %s", vmName, err, strings.TrimSpace(output))
 	}
 
 	return nil

--- a/pkg/deploy/windows-hyperv-destroy_test.go
+++ b/pkg/deploy/windows-hyperv-destroy_test.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,21 +117,36 @@ func TestHypervStartTargetStateFromVMState(t *testing.T) {
 	}
 }
 
-func TestRunHypervVagrantStopOnWindows_TreatsGracefulHaltErrorAsSuccessOnceStopped(t *testing.T) {
+func TestRunHypervVagrantStopOnWindows_UsesHypervGracefulStopForUbuntu(t *testing.T) {
 	restore := stubHypervStopDependencies(t)
 	defer restore()
-	vagrantRoot := setHypervTestVagrantRoot(t)
+	_ = setHypervTestVagrantRoot(t)
 
-	commands := make([][]string, 0, 1)
-	runHypervVagrantCommandWithEnv = func(_ string, _ time.Duration, executable string, args []string, env []string, _ string) error {
-		if executable != "vagrant" {
-			t.Fatalf("expected vagrant executable, got %q", executable)
+	runHypervVagrantCommandWithEnv = func(_ string, _ time.Duration, executable string, args []string, _ []string, _ string) error {
+		t.Fatalf("did not expect forced halt when graceful Hyper-V stop succeeds, got %q %v", executable, args)
+		return nil
+	}
+	runHypervCommandWithCombinedOutput = func(workingDir string, timeout time.Duration, executable string, args []string) (string, error) {
+		if executable != "powershell" {
+			t.Fatalf("expected powershell executable, got %q", executable)
 		}
-		assertEnvContainsEntry(t, env, "VAGRANT_BOX_NAME=linux-ubuntu-server-packer")
-		assertEnvContainsEntry(t, env, "VAGRANT_VM_NAME=linux-ubuntu-server-packer")
-		assertEnvContainsEntry(t, env, "VAGRANT_DOTFILE_PATH="+filepath.Join(vagrantRoot, "linux-ubuntu-server-packer"))
-		commands = append(commands, append([]string(nil), args...))
-		return fmt.Errorf("command failed (vagrant [halt]): exit status 1")
+		if workingDir == "" {
+			t.Fatal("expected working directory to be set")
+		}
+		if timeout != 2*time.Minute {
+			t.Fatalf("expected 2 minute timeout, got %s", timeout)
+		}
+		if len(args) < 4 || args[0] != "-NoProfile" || args[1] != "-NonInteractive" || args[2] != "-Command" {
+			t.Fatalf("unexpected powershell args: %v", args)
+		}
+		command := args[3]
+		if !strings.Contains(command, "Stop-VM -Name 'linux-ubuntu-server-packer' -Confirm:$false -ErrorAction Stop") {
+			t.Fatalf("expected Stop-VM command for ubuntu guest, got %q", command)
+		}
+		if !strings.Contains(command, "Import-Module Hyper-V -ErrorAction Stop") {
+			t.Fatalf("expected Hyper-V module import, got %q", command)
+		}
+		return "", nil
 	}
 
 	inspectCalls := 0
@@ -156,22 +172,26 @@ func TestRunHypervVagrantStopOnWindows_TreatsGracefulHaltErrorAsSuccessOnceStopp
 	}
 
 	if err := RunHypervVagrantStopOnWindows(config); err != nil {
-		t.Fatalf("expected graceful halt error to be ignored once stopped, got %v", err)
-	}
-	if len(commands) != 1 {
-		t.Fatalf("expected one halt attempt, got %d", len(commands))
-	}
-	if got := commands[0]; len(got) != 1 || got[0] != "halt" {
-		t.Fatalf("expected graceful halt command, got %#v", got)
+		t.Fatalf("expected graceful Hyper-V stop to succeed, got %v", err)
 	}
 }
 
-func TestRunHypervVagrantStopOnWindows_FallsBackToForcedHalt(t *testing.T) {
+func TestRunHypervVagrantStopOnWindows_FallsBackToForcedHaltAfterUbuntuGracefulStop(t *testing.T) {
 	restore := stubHypervStopDependencies(t)
 	defer restore()
 	vagrantRoot := setHypervTestVagrantRoot(t)
 
-	commands := make([][]string, 0, 2)
+	runHypervCommandWithCombinedOutput = func(_ string, _ time.Duration, executable string, args []string) (string, error) {
+		if executable != "powershell" {
+			t.Fatalf("expected powershell executable, got %q", executable)
+		}
+		if len(args) < 4 || !strings.Contains(args[3], "Stop-VM -Name 'linux-ubuntu-desktop-packer' -Confirm:$false -ErrorAction Stop") {
+			t.Fatalf("unexpected powershell args: %v", args)
+		}
+		return "", nil
+	}
+
+	commands := make([][]string, 0, 1)
 	runHypervVagrantCommandWithEnv = func(_ string, _ time.Duration, executable string, args []string, env []string, _ string) error {
 		if executable != "vagrant" {
 			t.Fatalf("expected vagrant executable, got %q", executable)
@@ -180,8 +200,8 @@ func TestRunHypervVagrantStopOnWindows_FallsBackToForcedHalt(t *testing.T) {
 		assertEnvContainsEntry(t, env, "VAGRANT_VM_NAME=linux-ubuntu-desktop-packer")
 		assertEnvContainsEntry(t, env, "VAGRANT_DOTFILE_PATH="+filepath.Join(vagrantRoot, "linux-ubuntu-desktop-packer"))
 		commands = append(commands, append([]string(nil), args...))
-		if len(args) == 1 && args[0] == "halt" {
-			return fmt.Errorf("command failed (vagrant [halt]): exit status 1")
+		if len(args) != 2 || args[0] != "halt" || args[1] != "--force" {
+			t.Fatalf("expected forced halt fallback, got %v", args)
 		}
 		return nil
 	}
@@ -214,14 +234,11 @@ func TestRunHypervVagrantStopOnWindows_FallsBackToForcedHalt(t *testing.T) {
 	if err := RunHypervVagrantStopOnWindows(config); err != nil {
 		t.Fatalf("expected forced halt fallback to succeed, got %v", err)
 	}
-	if len(commands) != 2 {
-		t.Fatalf("expected graceful and forced halt attempts, got %d", len(commands))
+	if len(commands) != 1 {
+		t.Fatalf("expected one forced halt attempt, got %d", len(commands))
 	}
-	if got := commands[0]; len(got) != 1 || got[0] != "halt" {
-		t.Fatalf("expected first command to be graceful halt, got %#v", got)
-	}
-	if got := commands[1]; len(got) != 2 || got[0] != "halt" || got[1] != "--force" {
-		t.Fatalf("expected second command to be forced halt, got %#v", got)
+	if got := commands[0]; len(got) != 2 || got[0] != "halt" || got[1] != "--force" {
+		t.Fatalf("expected forced halt command, got %#v", got)
 	}
 }
 
@@ -229,9 +246,12 @@ func TestRunHypervVagrantStopOnWindows_ReturnsErrorWhenVMStillRunningAfterForced
 	restore := stubHypervStopDependencies(t)
 	defer restore()
 
+	runHypervCommandWithCombinedOutput = func(_ string, _ time.Duration, _ string, _ []string) (string, error) {
+		return "", nil
+	}
 	runHypervVagrantCommandWithEnv = func(_ string, _ time.Duration, _ string, args []string, _ []string, _ string) error {
-		if len(args) == 1 && args[0] == "halt" {
-			return fmt.Errorf("command failed (vagrant [halt]): exit status 1")
+		if len(args) != 2 || args[0] != "halt" || args[1] != "--force" {
+			t.Fatalf("expected forced halt args, got %v", args)
 		}
 		return nil
 	}
@@ -252,8 +272,62 @@ func TestRunHypervVagrantStopOnWindows_ReturnsErrorWhenVMStillRunningAfterForced
 	if err == nil {
 		t.Fatal("expected stop to fail when VM remains running")
 	}
-	if err.Error() != "failed to stop Vagrant VM for ubuntu:server:amd64: graceful halt failed: command failed (vagrant [halt]): exit status 1; forced halt completed but VM is still running" {
+	if err.Error() != "failed to stop Vagrant VM for ubuntu:server:amd64: graceful stop failed: graceful stop completed but VM is still running after 0s; forced halt completed but VM is still running" {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunHypervVagrantStopOnWindows_UsesVagrantHaltForWindowsGuests(t *testing.T) {
+	restore := stubHypervStopDependencies(t)
+	defer restore()
+	vagrantRoot := setHypervTestVagrantRoot(t)
+
+	runHypervCommandWithCombinedOutput = func(_ string, _ time.Duration, executable string, _ []string) (string, error) {
+		t.Fatalf("did not expect powershell graceful stop for windows guest, got %q", executable)
+		return "", nil
+	}
+
+	commands := make([][]string, 0, 1)
+	runHypervVagrantCommandWithEnv = func(_ string, _ time.Duration, executable string, args []string, env []string, _ string) error {
+		if executable != "vagrant" {
+			t.Fatalf("expected vagrant executable, got %q", executable)
+		}
+		assertEnvContainsEntry(t, env, "VAGRANT_BOX_NAME=win11-packer")
+		assertEnvContainsEntry(t, env, "VAGRANT_VM_NAME=win11-packer")
+		assertEnvContainsEntry(t, env, "VAGRANT_DOTFILE_PATH="+filepath.Join(vagrantRoot, "win11-packer"))
+		commands = append(commands, append([]string(nil), args...))
+		return fmt.Errorf("command failed (vagrant [halt]): exit status 1")
+	}
+
+	inspectCalls := 0
+	inspectHypervVagrantStopTarget = func(alchemy_build.VirtualMachineConfig) (StartTargetState, error) {
+		inspectCalls++
+		switch inspectCalls {
+		case 1:
+			return StartTargetState{Exists: true, Running: true, State: "running"}, nil
+		case 2:
+			return StartTargetState{Exists: true, Running: false, State: "off"}, nil
+		default:
+			t.Fatalf("unexpected inspect call %d", inspectCalls)
+			return StartTargetState{}, nil
+		}
+	}
+
+	config := alchemy_build.VirtualMachineConfig{
+		OS:                   "windows11",
+		Arch:                 "amd64",
+		HostOs:               alchemy_build.HostOsWindows,
+		VirtualizationEngine: alchemy_build.VirtualizationEngineHyperv,
+	}
+
+	if err := RunHypervVagrantStopOnWindows(config); err != nil {
+		t.Fatalf("expected graceful Vagrant halt error to be ignored once stopped, got %v", err)
+	}
+	if len(commands) != 1 {
+		t.Fatalf("expected one halt attempt, got %d", len(commands))
+	}
+	if got := commands[0]; len(got) != 1 || got[0] != "halt" {
+		t.Fatalf("expected graceful halt command, got %#v", got)
 	}
 }
 
@@ -393,6 +467,7 @@ func stubHypervStopDependencies(t *testing.T) func() {
 	t.Helper()
 
 	originalRun := runHypervVagrantCommandWithEnv
+	originalRunCombined := runHypervCommandWithCombinedOutput
 	originalInspectStart := inspectHypervVagrantStartCmdTarget
 	originalInspect := inspectHypervVagrantStopTarget
 	originalMachineExists := hypervVagrantMachineExistsChecker
@@ -407,6 +482,7 @@ func stubHypervStopDependencies(t *testing.T) func() {
 
 	return func() {
 		runHypervVagrantCommandWithEnv = originalRun
+		runHypervCommandWithCombinedOutput = originalRunCombined
 		inspectHypervVagrantStartCmdTarget = originalInspectStart
 		inspectHypervVagrantStopTarget = originalInspect
 		hypervVagrantMachineExistsChecker = originalMachineExists

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -693,7 +693,11 @@ func extractLinuxIPv4FromSSHConfig(output string) (string, error) {
 		if parsedIP == nil {
 			continue
 		}
-		ip := parsedIP.String()
+		ipv4 := parsedIP.To4()
+		if ipv4 == nil {
+			continue
+		}
+		ip := ipv4.String()
 		if _, isLoopback := loopbackAddressSet[ip]; isLoopback {
 			continue
 		}

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -92,6 +92,7 @@ const (
 var (
 	windowsIPv4Regex   = regexp.MustCompile(`(?mi)IPv4 Address[^:]*:\s*((?:\d{1,3}\.){3}\d{1,3})`)
 	linuxIPv4Regex     = regexp.MustCompile(`(?m)\b((?:\d{1,3}\.){3}\d{1,3})\b`)
+	sshConfigHostRegex = regexp.MustCompile(`(?mi)^\s*HostName\s+([^\s#]+)\s*$`)
 	utmMacAddressRegex = regexp.MustCompile(`(?s)<key>MacAddress</key>\s*<string>([^<]+)</string>`)
 	arpEntryRegex      = regexp.MustCompile(`(?i)\((\d{1,3}(?:\.\d{1,3}){3})\)\s+at\s+([0-9a-f:-]+|<incomplete>)`)
 	loopbackAddressSet = map[string]struct{}{
@@ -625,6 +626,20 @@ func discoverWindowsVagrantIPv4(vagrantDir string, env []string) (string, error)
 }
 
 func discoverLinuxVagrantIPv4(vagrantDir string, env []string) (string, error) {
+	sshConfigOutput, sshConfigErr := runProvisionCommandWithCombinedOutputWithEnv(
+		vagrantDir,
+		3*time.Minute,
+		"vagrant",
+		[]string{"ssh-config"},
+		env,
+	)
+	if sshConfigErr == nil {
+		ip, parseErr := extractLinuxIPv4FromSSHConfig(sshConfigOutput)
+		if parseErr == nil {
+			return ip, nil
+		}
+	}
+
 	output, err := runProvisionCommandWithCombinedOutputWithEnv(
 		vagrantDir,
 		3*time.Minute,
@@ -661,6 +676,31 @@ func extractWindowsIPv4FromIPConfig(output string) (string, error) {
 	}
 
 	return "", errors.New("only loopback or invalid IPv4 candidates found in command output")
+}
+
+func extractLinuxIPv4FromSSHConfig(output string) (string, error) {
+	matches := sshConfigHostRegex.FindAllStringSubmatch(output, -1)
+	if len(matches) == 0 {
+		return "", errors.New("no HostName entry found in ssh-config output")
+	}
+
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		hostName := strings.TrimSpace(match[1])
+		parsedIP := net.ParseIP(hostName)
+		if parsedIP == nil {
+			continue
+		}
+		ip := parsedIP.String()
+		if _, isLoopback := loopbackAddressSet[ip]; isLoopback {
+			continue
+		}
+		return ip, nil
+	}
+
+	return "", errors.New("no non-loopback IPv4 address found in ssh-config HostName entries")
 }
 
 func extractLinuxIPv4FromHostOutput(output string) (string, error) {

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -87,7 +87,7 @@ func TestDiscoverLinuxVagrantIPv4_FallsBackToSSHCommandWhenSSHConfigLacksIP(t *t
 		calls = append(calls, strings.Join(args, " "))
 		switch strings.Join(args, " ") {
 		case "ssh-config":
-			return "Host default\n  HostName localhost\n", nil
+			return "Host default\n  HostName ::1\n", nil
 		case "ssh -c hostname -I":
 			return "127.0.0.1 172.25.125.159\n", nil
 		default:
@@ -1339,6 +1339,24 @@ func TestExtractLinuxIPv4FromSSHConfig(t *testing.T) {
 	output := `
 Host default
   HostName 127.0.0.1
+
+Host vm
+  HostName 172.24.78.254
+`
+
+	ip, err := extractLinuxIPv4FromSSHConfig(output)
+	if err != nil {
+		t.Fatalf("expected ssh-config IP extraction to succeed, got error: %v", err)
+	}
+	if ip != "172.24.78.254" {
+		t.Fatalf("expected 172.24.78.254, got %s", ip)
+	}
+}
+
+func TestExtractLinuxIPv4FromSSHConfig_IgnoresIPv6Entries(t *testing.T) {
+	output := `
+Host default
+  HostName ::1
 
 Host vm
   HostName 172.24.78.254

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -43,7 +43,9 @@ func TestDiscoverLinuxVagrantIPv4_UsesProvidedVagrantEnv(t *testing.T) {
 		runProvisionCommandWithCombinedOutputWithEnv = previousRunner
 	})
 
+	callCount := 0
 	runProvisionCommandWithCombinedOutputWithEnv = func(workingDir string, timeout time.Duration, executable string, args []string, extraEnv []string) (string, error) {
+		callCount++
 		if workingDir != "vagrant-dir" {
 			t.Fatalf("expected working directory to be passed through, got %q", workingDir)
 		}
@@ -53,13 +55,13 @@ func TestDiscoverLinuxVagrantIPv4_UsesProvidedVagrantEnv(t *testing.T) {
 		if timeout != 3*time.Minute {
 			t.Fatalf("expected 3 minute timeout, got %s", timeout)
 		}
-		if strings.Join(args, " ") != "ssh -c hostname -I" {
-			t.Fatalf("expected ssh hostname lookup args, got %v", args)
+		if strings.Join(args, " ") != "ssh-config" {
+			t.Fatalf("expected ssh-config lookup args, got %v", args)
 		}
 		if len(extraEnv) != 1 || extraEnv[0] != "VAGRANT_DOTFILE_PATH=.vagrant/linux-ubuntu-desktop-packer" {
 			t.Fatalf("expected Vagrant env to be forwarded, got %v", extraEnv)
 		}
-		return "127.0.0.1 172.25.125.159\n", nil
+		return "Host default\n  HostName 172.25.125.159\n", nil
 	}
 
 	ip, err := discoverLinuxVagrantIPv4("vagrant-dir", []string{"VAGRANT_DOTFILE_PATH=.vagrant/linux-ubuntu-desktop-packer"})
@@ -68,6 +70,41 @@ func TestDiscoverLinuxVagrantIPv4_UsesProvidedVagrantEnv(t *testing.T) {
 	}
 	if ip != "172.25.125.159" {
 		t.Fatalf("expected discovered IP 172.25.125.159, got %q", ip)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected ssh-config lookup to avoid fallback, got %d calls", callCount)
+	}
+}
+
+func TestDiscoverLinuxVagrantIPv4_FallsBackToSSHCommandWhenSSHConfigLacksIP(t *testing.T) {
+	previousRunner := runProvisionCommandWithCombinedOutputWithEnv
+	t.Cleanup(func() {
+		runProvisionCommandWithCombinedOutputWithEnv = previousRunner
+	})
+
+	var calls []string
+	runProvisionCommandWithCombinedOutputWithEnv = func(workingDir string, timeout time.Duration, executable string, args []string, extraEnv []string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		switch strings.Join(args, " ") {
+		case "ssh-config":
+			return "Host default\n  HostName localhost\n", nil
+		case "ssh -c hostname -I":
+			return "127.0.0.1 172.25.125.159\n", nil
+		default:
+			t.Fatalf("unexpected vagrant args: %v", args)
+			return "", nil
+		}
+	}
+
+	ip, err := discoverLinuxVagrantIPv4("vagrant-dir", []string{"VAGRANT_DOTFILE_PATH=.vagrant/linux-ubuntu-desktop-packer"})
+	if err != nil {
+		t.Fatalf("discoverLinuxVagrantIPv4 returned error: %v", err)
+	}
+	if ip != "172.25.125.159" {
+		t.Fatalf("expected discovered IP 172.25.125.159, got %q", ip)
+	}
+	if strings.Join(calls, " -> ") != "ssh-config -> ssh -c hostname -I" {
+		t.Fatalf("expected ssh-config fallback sequence, got %v", calls)
 	}
 }
 
@@ -1292,6 +1329,24 @@ default:
 	ip, err := extractLinuxIPv4FromHostOutput(output)
 	if err != nil {
 		t.Fatalf("expected IP extraction to succeed, got error: %v", err)
+	}
+	if ip != "172.24.78.254" {
+		t.Fatalf("expected 172.24.78.254, got %s", ip)
+	}
+}
+
+func TestExtractLinuxIPv4FromSSHConfig(t *testing.T) {
+	output := `
+Host default
+  HostName 127.0.0.1
+
+Host vm
+  HostName 172.24.78.254
+`
+
+	ip, err := extractLinuxIPv4FromSSHConfig(output)
+	if err != nil {
+		t.Fatalf("expected ssh-config IP extraction to succeed, got error: %v", err)
 	}
 	if ip != "172.24.78.254" {
 		t.Fatalf("expected 172.24.78.254, got %s", ip)

--- a/renovate.json
+++ b/renovate.json
@@ -30,8 +30,9 @@
         "(?<plugin>[a-z0-9-]+)\\s*=\\s*\\{\\s*source\\s*=\\s*\"github.com/hashicorp/[^\"]+\"\\s*\\n\\s*version\\s*=\\s*\"[~><= ]*(?<currentValue>[0-9][^\"]*)\"\\s*\\}",
         "(?<plugin>[a-z0-9-]+)\\s*=\\s*\\{\\s*version\\s*=\\s*\"[~><= ]*(?<currentValue>[0-9][^\"]*)\"\\s*\\n\\s*source\\s*=\\s*\"github.com/hashicorp/[^\"]+\"\\s*\\}"
       ],
-      "depNameTemplate": "hashicorp/{{{plugin}}}",
-      "datasourceTemplate": "github-releases"
+      "depNameTemplate": "hashicorp/packer-plugin-{{{plugin}}}",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -13,10 +13,11 @@
       "managerFilePatterns": [
         "/(^|/)pkg/build/dependencies\\.go$/",
         "/(^|/)build/packer/linux/ubuntu/linux-ubuntu-(on-macos|qemu)\\.sh$/",
-        "/(^|/)scripts/macos/download-virtio-win-iso\\.sh$/"
+        "/(^|/)scripts/macos/download-virtio-win-iso\\.sh$/",
+        "/(^|/)scripts/windows/dev-alchemy-self-setup\\.ps1$/"
       ],
       "matchStrings": [
-        "(?:#|//)\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+versioning=(?<versioning>\\S+)\\s+[A-Za-z0-9_]+\\s*=\\s+\"(?<currentValue>[^\"]+)\"(?:\\s+[A-Za-z0-9_]+\\s*=\\s+\"(?<currentDigest>[a-f0-9]+)\")?"
+        "(?:#|//)\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+versioning=(?<versioning>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+\\$?[A-Za-z0-9_]+\\s*=\\s+\"(?<currentValue>[^\"]+)\"(?:\\s+\\$?[A-Za-z0-9_]+\\s*=\\s+\"(?<currentDigest>[a-f0-9]+)\")?"
       ]
     },
     {
@@ -93,19 +94,6 @@
       ],
       "depNameTemplate": "actions/runner",
       "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "description": "Update Python version in the Azure runner image",
-      "managerFilePatterns": [
-        "/(^|/)build/gh_actions/windows-azure-gh-runner\\.pkr\\.hcl$/"
-      ],
-      "matchStrings": [
-        "choco install -y python --version=(?<currentValue>[0-9.]+)"
-      ],
-      "depNameTemplate": "python",
-      "datasourceTemplate": "python-version",
-      "versioningTemplate": "python"
     }
   ],
   "customDatasources": {

--- a/scripts/windows/dev-alchemy-self-setup.ps1
+++ b/scripts/windows/dev-alchemy-self-setup.ps1
@@ -1,4 +1,5 @@
 param(
+    [switch]$WithGo,
     [switch]$VirtualBox
 )
 
@@ -36,7 +37,7 @@ $cygwinPackages = @(
     "gcc-core",
     "gcc-g++",
     "libffi-devel",
-    "openssl-devel",
+    "libssl-devel",
     "sshpass"
 )
 
@@ -44,6 +45,42 @@ function Test-IsAdministrator {
     return ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
         [Security.Principal.WindowsBuiltInRole] "Administrator"
     )
+}
+
+function Invoke-SelfElevated {
+    $scriptPath = $PSCommandPath
+    if (-not $scriptPath) {
+        $scriptPath = $MyInvocation.MyCommand.Path
+    }
+    if (-not $scriptPath) {
+        throw "Unable to determine the installer script path for elevation."
+    }
+
+    $argumentList = @(
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", $scriptPath
+    )
+    if ($WithGo) {
+        $argumentList += "-WithGo"
+    }
+    if ($VirtualBox) {
+        $argumentList += "-VirtualBox"
+    }
+
+    Write-Output "Requesting administrator privileges through UAC..."
+
+    try {
+        $process = Start-Process -FilePath "powershell.exe" -ArgumentList $argumentList -Verb RunAs -WorkingDirectory (Get-Location).Path -Wait -PassThru
+    } catch [System.ComponentModel.Win32Exception] {
+        if ($_.Exception.NativeErrorCode -eq 1223) {
+            throw "Administrator privileges are required to continue. The UAC prompt was cancelled."
+        }
+        throw
+    }
+
+    exit $process.ExitCode
 }
 
 function Refresh-ProcessPath {
@@ -138,6 +175,62 @@ function Ensure-ChocolateyPackage {
     }
 
     Refresh-ProcessPath
+}
+
+function Ensure-GoInstallRootClean {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DesiredVersion
+    )
+
+    $goInstallRoot = "C:\Program Files\Go"
+    $goExePath = Join-Path $goInstallRoot "bin\go.exe"
+    $staleSwissMapPath = Join-Path $goInstallRoot "src\internal\abi\map_swiss.go"
+    $installedVersion = Get-ChocolateyInstalledVersion -PackageName "golang"
+
+    $shouldRemove = $false
+
+    if ($installedVersion -and $installedVersion -ne $DesiredVersion) {
+        Write-Output "Go $installedVersion detected. Removing the existing GOROOT before installing $DesiredVersion to avoid stale standard-library files."
+        $shouldRemove = $true
+    } elseif (Test-Path $staleSwissMapPath) {
+        Write-Output "A stale Go source file was detected at $staleSwissMapPath. Removing the existing GOROOT before reinstalling Go."
+        $shouldRemove = $true
+    } elseif ((-not $installedVersion) -and (Test-Path $goExePath)) {
+        Write-Output "An unmanaged Go installation was detected at $goInstallRoot. Removing it so the pinned Chocolatey install can start from a clean state."
+        $shouldRemove = $true
+    }
+
+    if (-not $shouldRemove) {
+        return
+    }
+
+    if (Test-Path $goInstallRoot) {
+        Remove-Item -Path $goInstallRoot -Recurse -Force
+    }
+
+    Refresh-ProcessPath
+}
+
+function Assert-GoToolchainLayout {
+    $goExe = Get-Command go -ErrorAction SilentlyContinue
+    if (-not $goExe) {
+        throw "Go was not found on PATH after installation."
+    }
+
+    $goRoot = (& go env GOROOT).Trim()
+    if (-not $goRoot) {
+        throw "Unable to determine GOROOT after installing Go."
+    }
+
+    $stalePaths = @(
+        (Join-Path $goRoot "src\internal\abi\map_swiss.go")
+    ) | Where-Object { Test-Path $_ }
+
+    if ($stalePaths.Count -gt 0) {
+        $staleList = $stalePaths -join ", "
+        throw "Detected stale Go standard-library source files after installation: $staleList. Remove $goRoot and reinstall Go."
+    }
 }
 
 function Get-CygwinRootDir {
@@ -269,12 +362,18 @@ function Ensure-CygwinPipPackage {
 }
 
 if (-not (Test-IsAdministrator)) {
-    throw "This script must be run as an Administrator."
+    Invoke-SelfElevated
 }
 
 Ensure-ChocolateyInstalled
 
-Ensure-ChocolateyPackage -PackageName "golang" -Version $golangVersion
+if ($WithGo) {
+    Ensure-GoInstallRootClean -DesiredVersion $golangVersion
+    Ensure-ChocolateyPackage -PackageName "golang" -Version $golangVersion
+    Assert-GoToolchainLayout
+} else {
+    Write-Output "Skipping Go installation because -WithGo was not specified."
+}
 Ensure-ChocolateyPackage -PackageName "git" -Version $gitVersion
 Ensure-ChocolateyPackage -PackageName "make" -Version $makeVersion
 Ensure-ChocolateyPackage -PackageName "packer" -Version $packerVersion
@@ -301,7 +400,9 @@ Ensure-CygwinPipPackage -PackageName "pywinrm" -Version $pywinrmVersion
 $bashExePath = Get-CygwinBashPath
 & $bashExePath -lc "python3 --version"
 & $bashExePath -lc "ansible --version"
-go version
+if ($WithGo) {
+    go version
+}
 git --version
 make --version
 packer version

--- a/scripts/windows/dev-alchemy-self-setup.ps1
+++ b/scripts/windows/dev-alchemy-self-setup.ps1
@@ -1,94 +1,308 @@
-# Check for administrative privileges
-if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    Write-Error "This script must be run as an Administrator."
-    exit 1
-}
+param(
+    [switch]$VirtualBox
+)
 
-# check if chocolatey is installed
-if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
-    Write-Output "Chocolatey not found. Installing Chocolatey..."
-    Set-ExecutionPolicy Bypass -Scope Process -Force
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-} else {
-    Write-Output "Chocolatey is already installed."
-}
+$ErrorActionPreference = "Stop"
 
-# Install virtualbox
-if (-not (Get-Command VirtualBox -ErrorAction SilentlyContinue)) {
-    Write-Output "VirtualBox not found. Installing VirtualBox..."
-    choco install virtualbox -y
-} else {
-    Write-Output "VirtualBox is already installed."
-}
+# renovate: datasource=nuget depName=golang versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$golangVersion = "1.26.2"
+# renovate: datasource=nuget depName=git versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$gitVersion = "2.54.0"
+# renovate: datasource=nuget depName=make versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$makeVersion = "4.4.1"
+# renovate: datasource=nuget depName=packer versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$packerVersion = "1.15.0"
+# renovate: datasource=nuget depName=azure-cli versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$azureCliVersion = "2.85.0"
+# renovate: datasource=nuget depName=cygwin versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$cygwinVersion = "3.6.7"
+# renovate: datasource=nuget depName=cyg-get versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$cygGetVersion = "1.2.2"
+# renovate: datasource=nuget depName=virtualbox versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$virtualBoxVersion = "7.2.6"
+# renovate: datasource=pypi depName=ansible versioning=pep440
+$ansibleVersion = "13.6.0"
+# renovate: datasource=pypi depName=pywinrm versioning=pep440
+$pywinrmVersion = "0.5.0"
 
-# Install Cygwin
-if (-not (Get-Command cygwin -ErrorAction SilentlyContinue)) {
-    Write-Output "Cygwin not found. Installing Cygwin..."
-    choco install cygwin -y
-} else {
-    Write-Output "Cygwin is already installed."
-}
-
-# Install cyg-get
-if (-not (Get-Command cyg-get -ErrorAction SilentlyContinue)) {
-    Write-Output "cyg-get not found. Installing cyg-get..."
-    choco install -y cyg-get
-} else {
-    Write-Output "cyg-get is already installed."
-}
-
-# Install required Cygwin packages
-$installedDb = "C:\tools\cygwin\etc\setup\installed.db"
-
-function Test-CygwinPackageInstalled {
-    param(
-        [string]$PackageName
-    )
-
-    if (-Not (Test-Path $installedDb)) {
-        Write-Error "installed.db not found at $installedDb"
-        return $false
-    }
-
-    $found = Select-String -Path $installedDb -Pattern "^(?i)$PackageName\s" -Quiet
-    return $found
-}
-
-$packages = @(
-    "python39",
-    "python39-pip",
-    "python39-cryptography",
+$cygwinInstallRoot = "C:\tools\cygwin"
+$cygwinPackages = @(
+    "python312",
+    "python312-pip",
+    "python312-cryptography",
     "openssh",
     "git",
     "make",
     "gcc-core",
-    "gcc-g\+\+",
+    "gcc-g++",
     "libffi-devel",
-    "libssl-devel",
+    "openssl-devel",
     "sshpass"
 )
-foreach ($package in $packages) {
-    if (Test-CygwinPackageInstalled -PackageName $package) {
-        Write-Output "$package is installed"
+
+function Test-IsAdministrator {
+    return ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [Security.Principal.WindowsBuiltInRole] "Administrator"
+    )
+}
+
+function Refresh-ProcessPath {
+    $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $env:Path = @($machinePath, $userPath) -join ";"
+}
+
+function Ensure-PathContains {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PathEntry
+    )
+
+    $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    $currentEntries = $machinePath -split ";" | Where-Object { $_ -ne "" }
+    if ($currentEntries -contains $PathEntry) {
+        return
+    }
+
+    [Environment]::SetEnvironmentVariable("Path", ($currentEntries + $PathEntry) -join ";", "Machine")
+    Refresh-ProcessPath
+}
+
+function Ensure-ChocolateyInstalled {
+    if (Get-Command choco -ErrorAction SilentlyContinue) {
+        Write-Output "Chocolatey is already installed."
+        return
+    }
+
+    Write-Output "Chocolatey not found. Installing Chocolatey..."
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString("https://community.chocolatey.org/install.ps1"))
+    Refresh-ProcessPath
+}
+
+function Get-ChocolateyInstalledVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName
+    )
+
+    $output = & choco list --local-only --exact $PackageName --limit-output 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    foreach ($line in $output) {
+        if ($line -match "^$([regex]::Escape($PackageName))\|(.+)$") {
+            return $Matches[1].Trim()
+        }
+    }
+
+    return $null
+}
+
+function Ensure-ChocolateyPackage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName,
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+        [string[]]$ExtraArgs = @()
+    )
+
+    $installedVersion = Get-ChocolateyInstalledVersion -PackageName $PackageName
+    if ($installedVersion -eq $Version) {
+        Write-Output "$PackageName $Version is already installed."
+        return
+    }
+
+    if ($installedVersion) {
+        Write-Output "$PackageName $installedVersion detected. Enforcing pinned version $Version..."
+        $command = "upgrade"
     } else {
-        Write-Output "$package is not installed"
-        cyg-get $package
+        Write-Output "$PackageName not found. Installing pinned version $Version..."
+        $command = "install"
+    }
+
+    $args = @($command, $PackageName, "-y", "--no-progress", "--version", $Version)
+    if ($command -eq "upgrade") {
+        $args += "--allow-downgrade"
+    }
+    if ($ExtraArgs.Count -gt 0) {
+        $args += $ExtraArgs
+    }
+
+    & choco @args
+    if ($LASTEXITCODE -notin @(0, 1641, 3010)) {
+        throw "Chocolatey failed to $command $PackageName $Version with exit code $LASTEXITCODE."
+    }
+
+    Refresh-ProcessPath
+}
+
+function Get-CygwinRootDir {
+    $registryKeys = @(
+        "HKLM:\SOFTWARE\Cygwin\setup",
+        "HKLM:\SOFTWARE\WOW6432Node\Cygwin\setup"
+    )
+
+    foreach ($registryKey in $registryKeys) {
+        if (-not (Test-Path $registryKey)) {
+            continue
+        }
+
+        $rootDir = (Get-ItemProperty -Path $registryKey -Name rootdir -ErrorAction SilentlyContinue).rootdir
+        if ($rootDir) {
+            return $rootDir
+        }
+    }
+
+    $fallbackCandidates = @(
+        $cygwinInstallRoot,
+        "C:\cygwin64",
+        "C:\cygwin",
+        "D:\cygwin"
+    )
+    foreach ($candidate in $fallbackCandidates) {
+        if (Test-Path (Join-Path $candidate "bin\bash.exe")) {
+            return $candidate
+        }
+    }
+
+    throw "Unable to locate the Cygwin installation root."
+}
+
+function Get-CygwinInstalledDbPath {
+    return Join-Path (Get-CygwinRootDir) "etc\setup\installed.db"
+}
+
+function Get-CygwinBashPath {
+    return Join-Path (Get-CygwinRootDir) "bin\bash.exe"
+}
+
+function Test-CygwinPackageInstalled {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName
+    )
+
+    $installedDb = Get-CygwinInstalledDbPath
+    if (-not (Test-Path $installedDb)) {
+        throw "installed.db not found at $installedDb"
+    }
+
+    return Select-String -Path $installedDb -Pattern "^(?i)$([regex]::Escape($PackageName))\s" -Quiet
+}
+
+function Ensure-CygwinPackage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName
+    )
+
+    if (Test-CygwinPackageInstalled -PackageName $PackageName) {
+        Write-Output "$PackageName is installed."
+        return
+    }
+
+    Write-Output "$PackageName is not installed. Installing..."
+    & cyg-get $PackageName
+    if ($LASTEXITCODE -ne 0) {
+        throw "cyg-get failed to install $PackageName with exit code $LASTEXITCODE."
     }
 }
 
-# Install ansible and pywinrm within Cygwin with pip
-$cygwinPipPackages = @("ansible", "pywinrm")
-$bashExePath = "C:\tools\cygwin\bin\bash.exe"
+function Get-CygwinPythonCommand {
+    return "python3"
+}
 
-foreach ($pkg in $cygwinPipPackages) {
-    if (-not (& $bashExePath -c "pip3 show $pkg" | Select-String -Pattern "Name: $pkg")) {
-        Write-Output "$pkg not found. Installing $pkg..."
-        & $bashExePath -c "pip3 install $pkg"
+function Get-CygwinPipPackageVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName
+    )
+
+    $bashExePath = Get-CygwinBashPath
+    $pythonCommand = Get-CygwinPythonCommand
+    $output = & $bashExePath -lc "$pythonCommand -m pip show $PackageName 2>/dev/null"
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    foreach ($line in $output) {
+        if ($line -match "^Version:\s+(.+)$") {
+            return $Matches[1].Trim()
+        }
+    }
+
+    return $null
+}
+
+function Ensure-CygwinPipPackage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName,
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    $installedVersion = Get-CygwinPipPackageVersion -PackageName $PackageName
+    if ($installedVersion -eq $Version) {
+        Write-Output "$PackageName $Version is already installed in Cygwin."
+        return
+    }
+
+    $bashExePath = Get-CygwinBashPath
+    $pythonCommand = Get-CygwinPythonCommand
+    $constraint = "'" + $PackageName + "==" + $Version + "'"
+
+    if ($installedVersion) {
+        Write-Output "$PackageName $installedVersion detected in Cygwin. Enforcing pinned version $Version..."
     } else {
-        Write-Output "$pkg is already installed."
+        Write-Output "$PackageName not found in Cygwin. Installing pinned version $Version..."
+    }
+
+    & $bashExePath -lc "$pythonCommand -m pip install --disable-pip-version-check --upgrade $constraint"
+    if ($LASTEXITCODE -ne 0) {
+        throw "pip failed to install $PackageName==$Version inside Cygwin with exit code $LASTEXITCODE."
     }
 }
 
-# Verify installations
-& $bashExePath -c "ansible --version"
+if (-not (Test-IsAdministrator)) {
+    throw "This script must be run as an Administrator."
+}
+
+Ensure-ChocolateyInstalled
+
+Ensure-ChocolateyPackage -PackageName "golang" -Version $golangVersion
+Ensure-ChocolateyPackage -PackageName "git" -Version $gitVersion
+Ensure-ChocolateyPackage -PackageName "make" -Version $makeVersion
+Ensure-ChocolateyPackage -PackageName "packer" -Version $packerVersion
+Ensure-ChocolateyPackage -PackageName "azure-cli" -Version $azureCliVersion
+Ensure-ChocolateyPackage -PackageName "cygwin" -Version $cygwinVersion -ExtraArgs @("--params", "`"/InstallDir:$cygwinInstallRoot /NoStartMenu`"")
+Ensure-ChocolateyPackage -PackageName "cyg-get" -Version $cygGetVersion
+
+if ($VirtualBox) {
+    Ensure-ChocolateyPackage -PackageName "virtualbox" -Version $virtualBoxVersion
+    Ensure-PathContains -PathEntry "C:\Program Files\Oracle\VirtualBox"
+} else {
+    Write-Output "Skipping VirtualBox installation because -VirtualBox was not specified."
+}
+
+Ensure-PathContains -PathEntry "C:\Program Files\Git\bin"
+
+foreach ($package in $cygwinPackages) {
+    Ensure-CygwinPackage -PackageName $package
+}
+
+Ensure-CygwinPipPackage -PackageName "ansible" -Version $ansibleVersion
+Ensure-CygwinPipPackage -PackageName "pywinrm" -Version $pywinrmVersion
+
+$bashExePath = Get-CygwinBashPath
+& $bashExePath -lc "python3 --version"
+& $bashExePath -lc "ansible --version"
+go version
+git --version
+make --version
+packer version
+az version

--- a/scripts/windows/dev-alchemy-self-setup.ps1
+++ b/scripts/windows/dev-alchemy-self-setup.ps1
@@ -15,7 +15,7 @@ $makeVersion = "4.4.1"
 $packerVersion = "1.15.0"
 # renovate: datasource=nuget depName=azure-cli versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
 $azureCliVersion = "2.85.0"
-# renovate: datasource=nuget depName=python314 versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+# renovate: datasource=nuget depName=python313 versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
 $nativePythonVersion = "3.13.13"
 # renovate: datasource=nuget depName=cygwin versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
 $cygwinVersion = "3.6.7"
@@ -171,12 +171,29 @@ function Ensure-ChocolateyPackage {
         $args += $ExtraArgs
     }
 
-    & choco @args
-    if ($LASTEXITCODE -notin @(0, 1641, 3010)) {
-        throw "Chocolatey failed to $command $PackageName $Version with exit code $LASTEXITCODE."
-    }
+    $maxAttempts = 3
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+        $chocoOutput = & choco @args 2>&1
+        $exitCode = $LASTEXITCODE
 
-    Refresh-ProcessPath
+        foreach ($line in $chocoOutput) {
+            Write-Output $line
+        }
+
+        if ($exitCode -in @(0, 1641, 3010)) {
+            Refresh-ProcessPath
+            return
+        }
+
+        $shouldRetry = $attempt -lt $maxAttempts -and (Test-ShouldRetryChocolateyCommand -OutputLines $chocoOutput)
+        if (-not $shouldRetry) {
+            throw "Chocolatey failed to $command $PackageName $Version with exit code $exitCode."
+        }
+
+        $sleepSeconds = 5 * $attempt
+        Write-Warning "Chocolatey failed to $command $PackageName $Version with exit code $exitCode. Retrying in $sleepSeconds seconds (attempt $($attempt + 1) of $maxAttempts)..."
+        Start-Sleep -Seconds $sleepSeconds
+    }
 }
 
 function Ensure-GoInstallRootClean {
@@ -240,6 +257,38 @@ function Assert-NativePythonAvailable {
     if (-not $pythonExe) {
         throw "Native Windows Python was not found on PATH after installation."
     }
+}
+
+function Get-NativePythonChocolateyPackageName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    $versionMatch = [regex]::Match($Version, "^(?<major>\d+)\.(?<minor>\d+)")
+    if (-not $versionMatch.Success) {
+        throw "Unable to derive the Chocolatey Python package name from version '$Version'."
+    }
+
+    return "python{0}{1}" -f $versionMatch.Groups["major"].Value, $versionMatch.Groups["minor"].Value
+}
+
+function Test-ShouldRetryChocolateyCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$OutputLines
+    )
+
+    $combinedOutput = ($OutputLines | Out-String)
+    return (
+        $combinedOutput -match "Response status code does not indicate success:\s+(408|429|5\d\d)" -or
+        $combinedOutput -match "Unable to connect to source" -or
+        $combinedOutput -match "The operation has timed out" -or
+        $combinedOutput -match "temporarily unavailable" -or
+        $combinedOutput -match "The remote name could not be resolved" -or
+        $combinedOutput -match "An error occurred while sending the request" -or
+        $combinedOutput -match "The request was aborted"
+    )
 }
 
 function Get-CygwinRootDir {
@@ -387,7 +436,8 @@ Ensure-ChocolateyPackage -PackageName "git" -Version $gitVersion
 Ensure-ChocolateyPackage -PackageName "make" -Version $makeVersion
 Ensure-ChocolateyPackage -PackageName "packer" -Version $packerVersion
 Ensure-ChocolateyPackage -PackageName "azure-cli" -Version $azureCliVersion
-Ensure-ChocolateyPackage -PackageName "python314" -Version $nativePythonVersion
+$nativePythonPackageName = Get-NativePythonChocolateyPackageName -Version $nativePythonVersion
+Ensure-ChocolateyPackage -PackageName $nativePythonPackageName -Version $nativePythonVersion
 Assert-NativePythonAvailable
 Ensure-ChocolateyPackage -PackageName "cygwin" -Version $cygwinVersion -ExtraArgs @("--params", "`"/InstallDir:$cygwinInstallRoot /NoStartMenu`"")
 Ensure-ChocolateyPackage -PackageName "cyg-get" -Version $cygGetVersion

--- a/scripts/windows/dev-alchemy-self-setup.ps1
+++ b/scripts/windows/dev-alchemy-self-setup.ps1
@@ -15,6 +15,8 @@ $makeVersion = "4.4.1"
 $packerVersion = "1.15.0"
 # renovate: datasource=nuget depName=azure-cli versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
 $azureCliVersion = "2.85.0"
+# renovate: datasource=nuget depName=python314 versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
+$nativePythonVersion = "3.13.13"
 # renovate: datasource=nuget depName=cygwin versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
 $cygwinVersion = "3.6.7"
 # renovate: datasource=nuget depName=cyg-get versioning=nuget registryUrl=https://community.chocolatey.org/api/v2/
@@ -233,6 +235,13 @@ function Assert-GoToolchainLayout {
     }
 }
 
+function Assert-NativePythonAvailable {
+    $pythonExe = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $pythonExe) {
+        throw "Native Windows Python was not found on PATH after installation."
+    }
+}
+
 function Get-CygwinRootDir {
     $registryKeys = @(
         "HKLM:\SOFTWARE\Cygwin\setup",
@@ -378,6 +387,8 @@ Ensure-ChocolateyPackage -PackageName "git" -Version $gitVersion
 Ensure-ChocolateyPackage -PackageName "make" -Version $makeVersion
 Ensure-ChocolateyPackage -PackageName "packer" -Version $packerVersion
 Ensure-ChocolateyPackage -PackageName "azure-cli" -Version $azureCliVersion
+Ensure-ChocolateyPackage -PackageName "python314" -Version $nativePythonVersion
+Assert-NativePythonAvailable
 Ensure-ChocolateyPackage -PackageName "cygwin" -Version $cygwinVersion -ExtraArgs @("--params", "`"/InstallDir:$cygwinInstallRoot /NoStartMenu`"")
 Ensure-ChocolateyPackage -PackageName "cyg-get" -Version $cygGetVersion
 
@@ -398,6 +409,7 @@ Ensure-CygwinPipPackage -PackageName "ansible" -Version $ansibleVersion
 Ensure-CygwinPipPackage -PackageName "pywinrm" -Version $pywinrmVersion
 
 $bashExePath = Get-CygwinBashPath
+python --version
 & $bashExePath -lc "python3 --version"
 & $bashExePath -lc "ansible --version"
 if ($WithGo) {


### PR DESCRIPTION
- make dev-alchemy-self-setup.ps1 the single source of truth for Windows packages
- add optional --virtualbox install flow and reuse the script in the golden runner image
- pin managed package versions and wire them into Renovate
- add packer init to the runner image build helper and provide example packer vars